### PR TITLE
add examples docstring of project module, format code, fix typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Python library for DaVinci Resolve (Repack)
 
-*🔥 Pybmd Now Support Both Windows & macOS 🔥*
+*🔥 PyBMD Now Support Both Windows & macOS 🔥*
 
 ## How To Install
 
@@ -15,21 +15,23 @@ pip install pybmd
 ```
 
 ## How To Use
->**⚠️Run Davinci Resolve before you run script**
 
-1. Init Resolve object use Bmd module
+>**⚠️Run DaVinci Resolve before you run script**
+
+1. Initialize Resolve object use Bmd module
+ 
    ```python
     from pybmd import Bmd
 
     LOCAL_RESOLVE = Bmd()
     ```
-    `Bmd()` has an option arg named `davinci_ip` , default value is `127.0.0.1 `stands for local davinci, if you want to use remote DaVinci Resolve object, change arg to remote ip.
+   
+    `Bmd()` has an optional arg named `davinci_ip`, default value is `127.0.0.1` stands for local DaVinci. If you want to use remote DaVinci Resolve object, change arg to remote IP.
 
 2. You are free now! 
 
     Play with APIs!
     
-    Original API documentation could be found at my notion:
-    [Davnci Resolve API in notion](https://wheheohu.notion.site/Davinci-Python-API-7c4f1038a36f44818b631ec7e4a537fa)
+    Original API documentation: [DaVinci Resolve API in Notion](https://wheheohu.notion.site/Davinci-Python-API-7c4f1038a36f44818b631ec7e4a537fa)
 
-    Pybmd Library API documentation could be found at :[Pybmd API Documentation](https://wheheohu.github.io/pybmd/)
+    PyBMD Library API documentation: [PyBMD API Documentation](https://wheheohu.github.io/pybmd/)

--- a/pybmd/project.py
+++ b/pybmd/project.py
@@ -1,20 +1,18 @@
-
-
 from dataclasses import asdict
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, List
+
 from pybmd.gallery import Gallery
 from pybmd.media_pool import MediaPool
-
 from pybmd.timeline import Timeline
-
 
 RenderResolution = List[dict]
 
 
 @dataclass
-class RenderSetting():
+class RenderSetting:
     """RenderSetting Object to store render setting."""
+
     SelectAllFrames: bool
     MarkIn: int
     MarkOut: int
@@ -27,13 +25,13 @@ class RenderSetting():
     FormatHeight: int
     FrameRate: float
 
-    # (for SD resolution: "16_9" or "4_3") (other resolutions: "square" or "cinemascope")
+    # (for SD resolution: "16_9" or "4_3") (other resolutions: "square" or
+    # "cinemascope")
     PixelAspectRatio: str
 
-    #  possible values for current codec (if applicable):
-    #  0(int) - will set quality to automatic
-    # [1 -> MAX] (int) - will set input bit rate
-    # ["Least", "Low", "Medium", "High", "Best"] (String) - will set input quality level
+    # possible values for current codec (if applicable): 0(int) - will set quality to
+    # automatic [1 -> MAX] (int) - will set input bit rate [ "Least", "Low", "Medium",
+    # "High", "Best"] (String) - will set input quality level
     VideoQuality: Any
 
     AudioCodec: str
@@ -50,17 +48,17 @@ class RenderSetting():
     # (example: "Main10"). Can only be set for H.264 and H.265.
     EncodingProfile: str
 
-    # Can onlt be set for H.264.
+    # Can only be set for H.264.
     MultiPassEncode: bool
 
-    # 0 - Premultipled, 1 - Straight. Can only be set if "ExportAlpha" is true.
+    # 0 - Premultiplied, 1 - Straight. Can only be set if "ExportAlpha" is true.
     AlphaMode: int
 
     # Only supported by QuickTime and MP4 formats.
     NetworkOptimization: bool
 
 
-class Project():
+class Project:
     """Project Object"""
 
     project = None
@@ -71,16 +69,18 @@ class Project():
         self.project = _project
 
     def __repr__(self) -> str:
-        return f'Project:{self.get_name()}'
+        return f"Project:{self.get_name()}"
 
     def get_self_project(self):
         return self.project
 
     def add_render_job(self) -> str:
-        """Adds a render job based on current render settings to the render queue. 
+        """Adds a render job based on current render settings to the render
+        queue.
 
         Returns:
             str: A unique job id (string) for the new render job.
+
         """
         return self.project.AddRenderJob()
 
@@ -93,7 +93,9 @@ class Project():
         return self.project.DeleteRenderJob(job_id)
 
     def get_current_render_format_and_codec(self) -> dict:
-        """Returns a dict with currently selected format 'format' and render codec 'codec'."""
+        """Returns a dict with currently selected format 'format' and render codec
+        'codec'.
+        """
         return self.project.GetCurrentRenderFormatAndCodec()
 
     def get_current_render_mode(self) -> int:
@@ -132,7 +134,9 @@ class Project():
         return self.project.GetRenderCodecs(render_format)
 
     def get_render_formats(self) -> dict:
-        """Returns a dict (format -> file extension) of available render formats."""
+        """Returns a dict (format -> file extension) of available render
+        formats.
+        """
         return self.project.GetRenderFormats()
 
     def get_render_job_list(self) -> list:
@@ -140,7 +144,9 @@ class Project():
         return self.project.GetRenderJobList()
 
     def get_render_job_status(self, job_id: str) -> dict:
-        """Returns a dict with job status and completion percentage of the job by given jobId (string)."""
+        """Returns a dict with job status and completion percentage of the
+        job by given jobId (string).
+        """
         return self.project.GetRenderJobStatus(job_id)
 
     def get_render_preset_list(self):
@@ -148,25 +154,53 @@ class Project():
         return self.project.GetRenderPresetList()
 
     def get_render_resolutions(self, format: str, codec: str) -> RenderResolution:
-        """Returns list of resolutions applicable for the given render format (string) and render codec (string). 
+        """Returns list of resolutions applicable for the given render format (string)
+        and render codec (string).
 
         Args:
-            format (str): format
-            codec (str): codec
+            format: format
+            codec: codec
 
         Returns:
-            RenderResolution: Returns full list of resolutions if no argument is provided. Each element in the list is a dictionary with 2 keys "Width" and "Height".
+            RenderResolution: Returns full list of resolutions if no argument is
+                provided. Each element in the list is a dictionary with 2 keys "Width"
+                and "Height".
+
+        Examples:
+            >>> from pybmd import Bmd
+            >>> LOCAL_RESOLVE = Bmd()
+            >>> project_manager = LOCAL_RESOLVE.get_project_manager()
+            >>> current_project = project_manager.get_current_project()
+            >>> current_project.get_render_resolutions(
+            ...     format="mp4",codec="h264"
+            ... )
+            [{'Width': 720, 'Height': 480},
+             {'Width': 720, 'Height': 486},
+             {'Width': 720, 'Height': 576},
+             ...]
+
         """
-        # Sample: current_project.get_render_resolutions(format='mp4',codec='h264')
         return self.project.GetRenderResolutions(format, codec)
 
     def get_setting(self, setting_name: str = "") -> str:
-        """Returns value of project setting (indicated by setting_name, string). """
-        # call *without parameters/NoneType * to get a snapshot of all queryable properties
+        """Returns value of project setting (indicated by setting_name, string).
+
+        Examples:
+            Call without parameters/NoneType to get a snapshot of all queryable
+            properties:
+
+            >>> from pybmd import Bmd
+            >>> LOCAL_RESOLVE = Bmd()
+            >>> project_manager = LOCAL_RESOLVE.get_project_manager()
+            >>> current_project = project_manager.get_current_project()
+            >>> current_project.get_setting()
+
+        """
         return self.project.GetSetting(setting_name)
 
     def get_timeline_by_index(self, idx) -> Timeline:
-        """Returns Timeline at the given index, 1 <= idx <= project.get_timeline_count()"""
+        """Returns Timeline at the given index, 1 <= idx <=
+        project.get_timeline_count()"""
         return Timeline(timeline=self.project.GetTimelineByIndex(idx))
 
     def get_timeline_count(self) -> int:
@@ -178,7 +212,9 @@ class Project():
         return self.project.IsRenderingInProgress()
 
     def load_render_preset(self, preset_name) -> bool:
-        """Sets a preset as current preset for rendering if preset_name (string) exists."""
+        """Sets a preset as current preset for rendering if preset_name ( string)
+        exists.
+        """
         return self.project.LoadRenderPreset(preset_name)
 
     def refresh_lut_list(self) -> bool:
@@ -190,22 +226,28 @@ class Project():
         return self.project.SaveAsNewRenderPreset(preset_name)
 
     def set_current_render_format_and_codec(self, format: str, codec: str) -> bool:
-        """Sets given render format (string) and render codec (string) as options for rendering."""
+        """Sets given render format (string) and render codec (string) as options for
+        rendering.
+        """
         return self.project.SetCurrentRenderFormatAndCodec(format, codec)
 
     def set_current_render_mode(self, render_mode: int) -> bool:
-        """Sets the render mode. 
+        """Sets the render mode.
 
         Args:
-            render_mode (int): Specify renderMode = 0 for Individual clips, 1 for Single clip.
+            render_mode: Specify renderMode = 0 for Individual clips, 1 for Single
+                 clip.
 
         Returns:
             bool: True if successful.
+
         """
         return self.project.SetCurrentRenderMode(render_mode)
 
     def set_current_timeline(self, timeline: Timeline) -> bool:
-        """Sets given Timeline as current timeline for the project. Returns True if successful."""
+        """Sets given Timeline as current timeline for the project. Returns True if
+        successful.
+        """
         return self.project.SetCurrentTimeline(timeline.timeline)
 
     def set_name(self, project_name) -> bool:
@@ -220,10 +262,11 @@ class Project():
         """Sets given settings for rendering.
 
         Args:
-            render_setting (RenderSetting): RenderSetting object
+            render_setting: RenderSetting object
 
         Returns:
             bool: True if successful.
+
         """
         if type(render_setting) is dict:
             return self.project.SetRenderSettings(render_setting)
@@ -234,17 +277,18 @@ class Project():
         """Sets value of project setting (indicated by setting_name, string).
 
         Args:
-            setting_name (str): Setting name
-            setting_value (str): Setting value
+            setting_name: Setting name
+            setting_value: Setting value
 
         Returns:
             _type_: True if successful.
+
         """
         return self.project.SetSetting(setting_name, setting_value)
 
     def start_rendering(self, job_ids: list, is_interactive_mode=False) -> bool:
-        """Start rendering. Returns True if successful.
-        if job_ids==None render all queued render jobs.
+        """Start rendering. Returns True if successful. if job_ids==None render all
+        queued render jobs.
         """
         return self.project.StartRendering(job_ids, is_interactive_mode)
 
@@ -252,39 +296,51 @@ class Project():
         """Stops rendering."""
         return self.project.StopRendering()
 
-    ##############################################################################################################################
+    ####################################################################################
     # Add at DR18.0.0
 
     def get_unique_id(self) -> str:
         """Returns unique id of the project Object."""
         return self.project.GetUniqueId()
 
-    ##############################################################################################################################
+    ####################################################################################
     # Add at DR18.1.3
 
-    def insert_audio_to_current_track_at_playhead(self, media_path: str, start_offset_in_samples: int, duration_in_samples: int) -> bool:
-        """Inserts the media specified by mediaPath (string) with startOffsetInSamples (int) and durationInSamples (int) at the playhead on a selected track on the Fairlight page. 
-        
+    def insert_audio_to_current_track_at_playhead(
+        self,
+        media_path: str,
+        start_offset_in_samples: int,
+        duration_in_samples: int,
+    ) -> bool:
+        """Inserts the media specified by mediaPath (string) with startOffsetInSamples
+        (int) and durationInSamples (int) at the playhead on a selected track on the
+        Fairlight page.
+
         Args:
-            media_path (str)
-            start_offset_in_samples (int)
-            duration_in_samples (int)
+            media_path
+            start_offset_in_samples
+            duration_in_samples
 
         Returns:
             bool: Returns True if successful, otherwise False.
-        """        
-        return self.project.InsertAudioToCurrentTrackAtPlayhead(media_path, start_offset_in_samples, duration_in_samples)
 
-    ##############################################################################################################################
+        """
+        return self.project.InsertAudioToCurrentTrackAtPlayhead(
+            media_path, start_offset_in_samples, duration_in_samples
+        )
+
+    ####################################################################################
     # Add at DR18.5.0
-    
-    def load_burn_in_preset(self,preset_name:str) -> bool:
-        """Loads user defined data burn in preset for project when supplied presetName (string). 
+
+    def load_burn_in_preset(self, preset_name: str) -> bool:
+        """Loads user defined data burn in preset for project when supplied presetName
+        (string).
 
         Args:
-            preset_name (str): preset name
+            preset_name: preset name
 
         Returns:
             bool: Returns true if successful.
-        """        
+
+        """
         return self.project.LoadBurnInPreset(preset_name)


### PR DESCRIPTION
- Refactor README. Fix formatting issues (unnecessary spaces and blank lines, cases, etc.)
- `project` module added "Examples" part of docstring to illustrate sample usage.
- Truncate long lines to 88 characters for readability (need more discussion on how many characters exactly are suitable for this project).