### PR TITLE
Fix bug for timeline_item.assign_to_color_group

### DIFF
--- a/pybmd/timeline_item.py
+++ b/pybmd/timeline_item.py
@@ -515,7 +515,7 @@ class TimelineItem():
         Returns:
             bool: Returns True if TiItem to successfully assigned to given ColorGroup. 
         """
-        return self._timeline_item.AssignToColorGroup(color_group)
+        return self._timeline_item.AssignToColorGroup(color_group._color_group)
 
     def remove_from_color_group(self) -> bool:
         """Returns True if the TiItem is successfully removed from the ColorGroup it is in.


### PR DESCRIPTION
in timeline_item.py, function assign_to_color_group()

change 
return self._timeline_item.AssignToColorGroup(color_group) 

to
return self._timeline_item.AssignToColorGroup(color_group._color_group)